### PR TITLE
fix csv content-type

### DIFF
--- a/templates/home_ethernet.tpl
+++ b/templates/home_ethernet.tpl
@@ -123,7 +123,7 @@ void submitValues() {
       // construct the HTTP POST request:
       sprintf_P(buffer,
                 PSTR("POST /boxes/%S/data HTTP/1.1\nHost: %S\nContent-Type: "
-                     "csv\nConnection: close\nContent-Length: %i\n"),
+                     "text/csv\nConnection: close\nContent-Length: %i\n"),
                 SENSEBOX_ID, server, num_measurements * 36);
       DEBUG(buffer);
 

--- a/templates/home_ethernet_feinstaub.tpl
+++ b/templates/home_ethernet_feinstaub.tpl
@@ -125,7 +125,7 @@ void submitValues() {
       // construct the HTTP POST request:
       sprintf_P(buffer,
                 PSTR("POST /boxes/%S/data HTTP/1.1\nHost: %S\nContent-Type: "
-                     "csv\nConnection: close\nContent-Length: %i\n"),
+                     "text/csv\nConnection: close\nContent-Length: %i\n"),
                 SENSEBOX_ID, server, num_measurements * 36);
       DEBUG(buffer);
 

--- a/templates/home_wifi.tpl
+++ b/templates/home_wifi.tpl
@@ -125,7 +125,7 @@ void submitValues() {
       // construct the HTTP POST request:
       sprintf_P(buffer,
                 PSTR("POST /boxes/%S/data HTTP/1.1\nHost: %S\nContent-Type: "
-                     "csv\nConnection: close\nContent-Length: %i\n"),
+                     "text/csv\nConnection: close\nContent-Length: %i\n"),
                 SENSEBOX_ID, server, num_measurements * 36);
       DEBUG(buffer);
 

--- a/templates/home_wifi_feinstaub.tpl
+++ b/templates/home_wifi_feinstaub.tpl
@@ -127,7 +127,7 @@ void submitValues() {
       // construct the HTTP POST request:
       sprintf_P(buffer,
                 PSTR("POST /boxes/%S/data HTTP/1.1\nHost: %S\nContent-Type: "
-                     "csv\nConnection: close\nContent-Length: %i\n"),
+                     "text/csv\nConnection: close\nContent-Length: %i\n"),
                 SENSEBOX_ID, server, num_measurements * 36);
       DEBUG(buffer);
 

--- a/templates/homev2_wifi.tpl
+++ b/templates/homev2_wifi.tpl
@@ -127,7 +127,7 @@ void submitValues() {
       // construct the HTTP POST request:
       sprintf_P(buffer,
                 PSTR("POST /boxes/%s/data HTTP/1.1\nHost: %s\nContent-Type: "
-                     "csv\nConnection: close\nContent-Length: %i\n\n"),
+                     "text/csv\nConnection: close\nContent-Length: %i\n\n"),
                 SENSEBOX_ID, server, num_measurements * 35);
       DEBUG_p(buffer);
 

--- a/templates/homev2_wifi_feinstaub.tpl
+++ b/templates/homev2_wifi_feinstaub.tpl
@@ -130,7 +130,7 @@ void submitValues() {
       // construct the HTTP POST request:
       sprintf_P(buffer,
                 PSTR("POST /boxes/%s/data HTTP/1.1\nHost: %s\nContent-Type: "
-                     "csv\nConnection: close\nContent-Length: %i\n\n"),
+                     "text/csv\nConnection: close\nContent-Length: %i\n\n"),
                 SENSEBOX_ID, server, num_measurements * 35);
       DEBUG_p(buffer);
 


### PR DESCRIPTION
As we encountered issues posting data we figured out that a wrong `Media Type` is used in `Content-Type` header. Fixed the encountered issues with changing `csv` to `text/csv`.

Check out valid [media types](https://www.iana.org/assignments/media-types/media-types.xhtml) 