### PR TITLE
Feat display eric

### DIFF
--- a/arduino-test/build-sketches.js
+++ b/arduino-test/build-sketches.js
@@ -73,7 +73,8 @@ const boxStub = function(model) {
     ],
     serialPort: 'Serial1',
     ssid: 'MY-HOME-NETWORK',
-    password: 'MY-SUPER-PASSWORD'
+    password: 'MY-SUPER-PASSWORD',
+    display_enabled:'true'
   };
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,8 @@ SketchTemplater.prototype._cloneBox = function _cloneBox({
   devEUI,
   appEUI,
   appKey,
-  access_token
+  access_token,
+  display_enabled
 }) {
   return Object.assign(
     {},
@@ -92,7 +93,8 @@ SketchTemplater.prototype._cloneBox = function _cloneBox({
       DEV_EUI: devEUI,
       APP_EUI: appEUI,
       APP_KEY: appKey,
-      ACCESS_TOKEN: access_token
+      ACCESS_TOKEN: access_token,
+      DISPLAY_ENABLED: display_enabled
     }
   );
 };

--- a/src/transformers.js
+++ b/src/transformers.js
@@ -72,6 +72,10 @@ module.exports = {
     if(display === 'true'){
       output.push(`#define DISPLAY128x64_CONNECTED`);
     }
+    else{
+      output.push(`//#define DISPLAY128x64_CONNECTED`);
+    }
+
     return output.join('\r\n');    
   }
 };

--- a/src/transformers.js
+++ b/src/transformers.js
@@ -66,5 +66,12 @@ module.exports = {
     }
 
     return `{${chunks.map(c => ` 0x${c}`)} }`;
+  },
+  toDefineDisplay(display){
+    const output = [];
+    if(display === 'true'){
+      output.push(`#define DISPLAY128x64_CONNECTED`);
+    }
+    return output.join('\r\n');    
   }
 };

--- a/templates/homev2_lora.tpl
+++ b/templates/homev2_lora.tpl
@@ -17,6 +17,8 @@
 #include <SPI.h>
 #include <senseBoxIO.h>
 
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
 #include <Adafruit_Sensor.h>
 #include <Adafruit_HDC1000.h>
 #include <Adafruit_BMP280.h>
@@ -38,6 +40,10 @@
 
 // Connected sensors
 @@SENSORS|toDefineWithSuffixPrefixAndKey~,_CONNECTED,sensorType@@
+
+// Display enabled 
+// Uncomment the next line to get values of measurements printed on display
+@@DISPLAY_ENABLED|toDefineDisplay@@
 
 // Number of serial port the SDS011 is connected to. Either Serial1 or Serial2
 #ifdef SDS011_CONNECTED
@@ -83,6 +89,10 @@
 #ifdef SCD30_CONNECTED
   SCD30 SCD;
 #endif
+#ifdef DISPLAY128x64_CONNECTED
+  #define OLED_RESET 4
+  Adafruit_SSD1306 display(OLED_RESET);
+#endif
 
 // This EUI must be in little-endian format, so least-significant-byte (lsb)
 // first. When copying an EUI from ttnctl output, this means to reverse
@@ -105,10 +115,18 @@ static const u1_t PROGMEM APPKEY[16] = @@APP_KEY|transformTTNID@@;
 void os_getDevKey (u1_t* buf) {  memcpy_P(buf, APPKEY, 16);}
 
 static osjob_t sendjob;
+#ifdef DISPLAY128x64_CONNECTED
+  static osjob_t displayjob;
+#endif
+
 
 // Schedule TX every this many seconds (might become longer due to duty
 // cycle limitations).
 const unsigned TX_INTERVAL = 60;
+#ifdef DISPLAY128x64_CONNECTED
+  const unsigned DISPLAY_INTERVAL = 5; // update display each 5 seconds
+  int unsigned displayPage = 0;
+#endif
 
 // Pin mapping
 const lmic_pinmap lmic_pins = {
@@ -322,6 +340,180 @@ void do_send(osjob_t* j){
   // Next TX is scheduled after TX_COMPLETE event.
 }
 
+#ifdef DISPLAY128x64_CONNECTED
+void update_display(osjob_t* t) {
+
+  display.clearDisplay();
+  display.setCursor(0, 0);
+  display.setTextSize(1);
+  display.setTextColor(WHITE, BLACK);
+  switch (displayPage)
+  {
+    case 0:
+      {
+        // HDC & BMP
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("HDC&BMP"));
+        display.setTextColor(WHITE, BLACK);
+        display.setTextSize(1);
+        display.print(F("Temp:"));
+#ifdef HDC1080_CONNECTED
+        display.println(HDC.readTemperature());
+#else
+        display.println(F("not connected"));
+#endif
+        display.println();
+        display.print(F("Humi:"));
+#ifdef HDC1080_CONNECTED
+        display.println(HDC.readHumidity());
+#else
+        display.println(F("not connected"));
+#endif
+        display.println();
+        display.print(F("Press.:"));
+#ifdef BMP280_CONNECTED
+        display.println(BMP.readPressure() / 100);
+#else
+        display.println(F("not connected"));
+#endif
+      }
+      break;
+    case 1:
+      {
+        // TSL/VEML
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("TSL&VEML"));
+        display.setTextColor(WHITE, BLACK);
+        display.println();
+        display.setTextSize(1);
+        display.print(F("Lux:"));
+#ifdef TSL45315_CONNECTED
+        display.println(TSL.readLux());
+#else
+        display.println(F("not connected"));
+#endif
+        display.println();
+        display.print("UV:");
+#ifdef VEML6070_CONNECTED
+        display.println(VEML.getUV());
+#else
+        display.println(F("not connected"));
+#endif
+      }
+      break;
+    case 2:
+      {
+        // SMT, SOUND LEVEL , BME
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("Soil"));
+        display.setTextColor(WHITE, BLACK);
+        display.println();
+        display.setTextSize(1);
+        display.print(F("Temp:"));
+#ifdef SMT50_CONNECTED
+        float volt = analogRead(SOILTEMPPIN) * (3.3 / 1024.0);
+        float soilTemperature = (volt - 0.5) * 100;
+        display.println(soilTemperature);
+#else
+        display.println(F("not connected"));
+#endif
+        display.println();
+        display.print(F("Moist:"));
+#ifdef SMT50_CONNECTED
+        volt = analogRead(SOILMOISPIN) * (3.3 / 1024.0);
+        float soilMoisture = (volt * 50) / 3;
+        display.println(soilMoisture);
+#else
+        display.println(F("not connected"));
+#endif
+      }
+      break;
+    case 3:
+      {
+        // WINDSPEED SCD30
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("Wind&SCD30"));
+        display.setTextColor(WHITE, BLACK);
+        display.println();
+        display.setTextSize(1);
+        display.print(F("Speed:"));
+#ifdef WINDSPEED_CONNECTED
+        float voltageWind = analogRead(WINDSPEEDPIN) * (3.3 / 1024.0);
+        float windspeed = 0.0;
+        if (voltageWind >= 0.018) {
+          float poly1 = pow(voltageWind, 3);
+          poly1 = 17.0359801998299 * poly1;
+          float poly2 = pow(voltageWind, 2);
+          poly2 = 47.9908168343362 * poly2;
+          float poly3 = 122.899677524413 * voltageWind;
+          float poly4 = 0.657504127272728;
+          windspeed = poly1 - poly2 + poly3 - poly4;
+          windspeed = windspeed * 0.2777777777777778; //conversion in m/s
+        }
+        display.println(windspeed);
+#else
+        display.println(F("not connected"));
+#endif
+        display.println();
+        display.print(F("SCD30:"));
+#ifdef SCD30_CONNECTED
+        display.println(SCD.getCO2());
+#else
+        display.println(F("not connected"));
+#endif
+      }
+      break;
+    case 4:
+      {
+        // SMT, SOUND LEVEL , BME
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("Sound&BME"));
+        display.setTextColor(WHITE, BLACK);
+        display.println();
+        display.setTextSize(1);
+        display.print(F("Sound:"));
+#ifdef SOUNDLEVELMETER_CONNECTED
+        float v = analogRead(SOUNDMETERPIN) * (3.3 / 1024.0);
+        float decibel = v * 50;
+        display.println(decibel);
+#else
+        display.println(F("not connected"));
+#endif
+        display.println();
+        display.print(F("Gas:"));
+#ifdef BME680_CONNECTED
+        uint16_t gasResistance = 0;
+        delay(100);
+        BME.setGasHeater(320, 150); // 320*C for 150 ms
+        if ( BME.performReading()) {
+          uint16_t gasResistance = BME.gas_resistance / 1000.0;
+        }
+        display.println(gasResistance);
+#else
+        display.print(F("not connected"));
+#endif
+      }
+      break;
+  }
+  display.display();
+
+
+  if (displayPage == 4) {
+    displayPage = 0;
+  }
+  else {
+    displayPage++;
+  }
+
+  os_setTimedCallback(&displayjob, os_getTime() + sec2osticks(DISPLAY_INTERVAL), update_display);
+}
+#endif
+
 void setup() {
   #ifdef ENABLE_DEBUG
     Serial.begin(9600);
@@ -362,6 +554,24 @@ void setup() {
     Wire.begin();
     SCD.begin();
   #endif
+  #ifdef DISPLAY128x64_CONNECTED
+    DEBUG(F("enable display..."));
+    delay(2000);
+    display.begin(SSD1306_SWITCHCAPVCC, 0x3D);
+    display.display();
+    delay(100);
+    display.clearDisplay();
+    DEBUG(F("done."));
+    display.setCursor(0, 0);
+    display.setTextSize(2);
+    display.setTextColor(WHITE, BLACK);
+    display.println("senseBox:");
+    display.println("home\n");
+    display.setTextSize(1);
+    display.println("Version LoRaWAN");
+    display.setTextSize(2);
+    display.display();
+  #endif
 
   DEBUG(F("Sensor initializing done!"));
   DEBUG(F("Starting loop in 3 seconds."));
@@ -374,6 +584,10 @@ void setup() {
 
   // Start job (sending automatically starts OTAA too)
   do_send(&sendjob);
+  #ifdef DISPLAY128x64_CONNECTED
+    update_display(&displayjob);
+  #endif
+
 }
 
 void loop() {

--- a/templates/homev2_wifi.tpl
+++ b/templates/homev2_wifi.tpl
@@ -67,6 +67,8 @@ static const uint8_t NUM_SENSORS = @@NUM_SENSORS@@;
 // Connected sensors
 @@SENSORS|toDefineWithSuffixPrefixAndKey~,_CONNECTED,sensorType@@
 
+// Display enabled 
+// Uncomment the next line to get values of measurements printed on display
 @@DISPLAY_ENABLED|toDefineDisplay@@
 
 // Sensor SENSOR_IDs

--- a/templates/homev2_wifi.tpl
+++ b/templates/homev2_wifi.tpl
@@ -464,7 +464,7 @@ void loop() {
   }
   BME.setGasHeater(320, 150); // 320*C for 150 ms
   if ( BME.performReading()) {
-           gasResistance = BME.gas_resistance / 1000.0
+      gasResistance = BME.gas_resistance / 1000.0;
        addMeasurement(VOCSENSOR_ID, gasResistance);
   }
 #endif

--- a/templates/homev2_wifi.tpl
+++ b/templates/homev2_wifi.tpl
@@ -101,6 +101,10 @@ WiFiSSLClient client;
 #ifdef SCD30_CONNECTED
   SCD30 SCD;
 #endif
+#ifdef DISPLAY128x64_CONNECTED
+#define OLED_RESET 4
+Adafruit_SSD1306 display(OLED_RESET);
+#endif
 
 typedef struct measurement {
   const char *sensorId;
@@ -287,6 +291,26 @@ void setup() {
   delay(200);
   senseBoxIO.powerI2C(true);
 
+#ifdef DISPLAY128x64_CONNECTED
+  DEBUG2(F("enable display..."));
+  delay(2000);
+  display.begin(SSD1306_SWITCHCAPVCC, 0x3D);
+  display.display();
+  delay(100);
+  display.clearDisplay();
+  DEBUG(F("done."));
+  display.setCursor(0, 0);
+  display.setTextSize(2);
+  display.setTextColor(WHITE, BLACK);
+  display.println("senseBox:");
+  display.println("home\n");
+  display.setTextSize(1);
+  display.println("Version Wifi ");
+  display.setTextSize(2);
+  display.display();
+  delay(2000);
+#endif
+
   // Check WiFi Bee status
   if (WiFi.status() == WL_NO_SHIELD) {
     DEBUG(F("WiFi shield not present"));
@@ -347,6 +371,17 @@ void setup() {
 
 void loop() {
   DEBUG(F("Starting new measurement..."));
+  #ifdef DISPLAY128x64_CONNECTED
+    long displayTime = 5000;
+    int page = 0;
+    
+    display.clearDisplay();
+    display.setCursor(0, 0);
+    display.setTextSize(1);
+    display.setTextColor(WHITE, BLACK);
+    display.println("Uploading new measurement... ");
+    display.display(); 
+  #endif
   // capture loop start timestamp
   unsigned long start = millis();
 
@@ -435,6 +470,144 @@ void loop() {
   for (;;) {
     unsigned long now = millis();
     unsigned long elapsed = now - start;
+#ifdef DISPLAY128x64_CONNECTED
+    display.clearDisplay();
+    display.setCursor(0, 0);
+    display.setTextSize(1);
+    display.setTextColor(WHITE, BLACK);
+    switch (page)
+    {
+    case 0:
+      // HDC & BMP
+      display.setTextSize(2);
+      display.setTextColor(BLACK, WHITE);
+      display.println(F("HDC&BMP"));
+      display.setTextColor(WHITE, BLACK);
+      display.println();
+      display.setTextSize(1);
+      display.print(F("Temp:"));
+#ifdef HDC1080_CONNECTED
+      display.println(HDC.readTemperature());
+#else
+      display.println(F("not connected"));
+#endif
+      display.print(F("Humi:"));
+#ifdef HDC1080_CONNECTED
+      display.println(HDC.readHumidity());
+#else
+      display.println(F("not connected"));
+#endif
+      display.print(F("Pressure:"));
+#ifdef BMP280_CONNECTED
+      display.println(BMP.readPressure() / 100);
+#else
+      display.println(F("not connected"));
+#endif
+      break;
+    case 1:
+      // TSL/VEML
+      display.setTextSize(2);
+      display.setTextColor(BLACK, WHITE);
+      display.println(F("TSL&VEML"));
+      display.setTextColor(WHITE, BLACK);
+      display.println();
+      display.setTextSize(1);
+      display.print(F("Lux:"));
+#ifdef TSL45315_CONNECTED
+      display.println(TSL.readLux());
+#else
+      display.println(F(F("not connected")));
+#endif
+      display.print("UV:");
+#ifdef VEML6070_CONNECTED
+      display.println(VEML.getUV());
+#else
+      display.println(F(F("not connected")));
+#endif
+      break;
+    case 2:
+      // SDS
+      display.setTextSize(2);
+      display.setTextColor(BLACK, WHITE);
+      display.println(F("PM10&PM25"));
+      display.setTextColor(WHITE, BLACK);
+      display.println();
+      display.setTextSize(1);
+      display.print(F("PM10:"));
+      display.println(TSL.readLux());
+      display.print(F("PM25:"));
+      display.println(VEML.getUV());
+      break;
+    case 3:
+      // SMT, SOUND LEVEL , BME
+      display.setTextSize(2);
+      display.setTextColor(BLACK, WHITE);
+      display.println(F("Soil"));
+      display.setTextColor(WHITE, BLACK);
+      display.println();
+      display.setTextSize(1);
+      display.print(F("Soil Temp:"));
+#ifdef SMT50_CONNECTED
+      display.println(soilTemperature);
+#else
+      display.println(F("not connected"));
+#endif
+      display.print(F("Soil moist"));
+#ifdef SMT50_CONNECTED
+      display.println(soilMoisture);
+#else
+      display.println(F("not connected"));
+#endif
+      display.print(F("SOUND:"));
+#ifdef SOUNDLEVELMETER_CONNECTED
+      display.println(decibel);
+#else
+      display.println(F("not connected"));
+#endif
+      display.print(F("Gas"));
+
+#ifdef BME680_CONNECTED
+      display.println(gasResistance);
+#else
+      display.print(F("not connected"));
+#endif
+      break;
+    case 4:
+      // WINDSPEED SCD30
+      display.setTextSize(2);
+      display.setTextColor(BLACK, WHITE);
+      display.println(F("Wind&SCD30"));
+      display.setTextColor(WHITE, BLACK);
+      display.println();
+      display.setTextSize(1);
+      display.print(F("Windspeed:"));
+#ifdef WINDSPEED_CONNECTED
+      display.println(windspeed);
+#else
+      display.println(F("not connected"));
+#endif
+      display.print(F("SCD30:"));
+#ifdef SCD30_CONNECTED
+      display.println(SCD.getCO2());
+#else
+      display.println(F("not connected"));
+#endif
+      break;
+    }
+    display.display();
+    if (elapsed >= displayTime)
+    {
+      if (page == 4)
+      {
+        page = 0;
+      }
+      else
+      {
+        page += 1;
+      }
+      displayTime += 5000;
+    }
+#endif
     if (elapsed >= postingInterval)
       return;
   }

--- a/templates/homev2_wifi.tpl
+++ b/templates/homev2_wifi.tpl
@@ -67,6 +67,9 @@ static const uint8_t NUM_SENSORS = @@NUM_SENSORS@@;
 // Connected sensors
 @@SENSORS|toDefineWithSuffixPrefixAndKey~,_CONNECTED,sensorType@@
 
+// Display Connected 
+@@DISPLAY_ENABLED|toDefineDisplay@@
+
 // Sensor SENSOR_IDs
 @@SENSOR_IDS|toProgmem@@
 

--- a/templates/homev2_wifi.tpl
+++ b/templates/homev2_wifi.tpl
@@ -456,6 +456,7 @@ void loop() {
   //-----BME680-----//
 #ifdef BME680_CONNECTED
   BME.setGasHeater(0, 0);
+  float gasResistance;
   if ( BME.performReading()) {
     addMeasurement(LUFTTESENSOR_ID, BME.temperature - 1);
     addMeasurement(LUFTFESENSOR_ID, BME.humidity);
@@ -463,7 +464,8 @@ void loop() {
   }
   BME.setGasHeater(320, 150); // 320*C for 150 ms
   if ( BME.performReading()) {
-    addMeasurement(VOCSENSOR_ID, BME.gas_resistance / 1000.0);
+           gasResistance = BME.gas_resistance / 1000.0
+       addMeasurement(VOCSENSOR_ID, gasResistance);
   }
 #endif
 

--- a/templates/homev2_wifi.tpl
+++ b/templates/homev2_wifi.tpl
@@ -315,6 +315,14 @@ void setup() {
   display.setTextSize(2);
   display.display();
   delay(2000);
+  display.clearDisplay();
+  display.setCursor(0, 0);
+  display.setTextSize(1);
+  display.println("Connecting to:");
+  display.println();
+  display.println(ssid);
+  display.setTextSize(1);
+  display.display();
 #endif
 
   // Check WiFi Bee status
@@ -326,6 +334,10 @@ void setup() {
   uint8_t status = WL_IDLE_STATUS;
   // attempt to connect to Wifi network:
   while (status != WL_CONNECTED) {
+#ifdef DISPLAY128x64_CONNECTED
+    display.print(".");
+    display.display();
+#endif
     DEBUG2(F("Attempting to connect to SSID: "));
     DEBUG(ssid);
     // Connect to WPA/WPA2 network. Change this line if using open or WEP
@@ -370,6 +382,13 @@ void setup() {
     Wire.begin();
     SCD.begin();
   #endif
+#ifdef DISPLAY128x64_CONNECTED
+  display.clearDisplay();
+  display.setCursor(30, 28);
+  display.setTextSize(2);
+  display.print("Ready!");
+  display.display();
+#endif
   DEBUG(F("Initializing sensors done!"));
   DEBUG(F("Starting loop in 3 seconds."));
   delay(3000);
@@ -377,105 +396,6 @@ void setup() {
 
 void loop() {
   DEBUG(F("Starting new measurement..."));
-  #ifdef DISPLAY128x64_CONNECTED
-    long displayTime = 5000;
-    int page = 0;
-    
-    display.clearDisplay();
-    display.setCursor(0, 0);
-    display.setTextSize(1);
-    display.setTextColor(WHITE, BLACK);
-    display.println("Uploading new measurement... ");
-    display.display(); 
-  #endif
-  // capture loop start timestamp
-  unsigned long start = millis();
-
-  //-----Temperature-----//
-  //-----Humidity-----//
-  #ifdef HDC1080_CONNECTED
-    addMeasurement(TEMPERSENSOR_ID, HDC.readTemperature());
-    delay(200);
-    addMeasurement(RELLUFSENSOR_ID, HDC.readHumidity());
-  #endif
-
-  //-----Pressure-----//
-  #ifdef BMP280_CONNECTED
-    float pressure;
-    pressure = BMP.readPressure()/100;
-    addMeasurement(LUFTDRSENSOR_ID, pressure);
-  #endif
-
-  //-----Lux-----//
-  #ifdef TSL45315_CONNECTED
-    addMeasurement(BELEUCSENSOR_ID, TSL.readLux());
-  #endif
-
-  //-----UV intensity-----//
-  #ifdef VEML6070_CONNECTED
-    addMeasurement(UVINTESENSOR_ID, VEML.getUV());
-  #endif
-
-  //-----Soil Temperature & Moisture-----//
-  #ifdef SMT50_CONNECTED
-    float voltage = analogRead(SOILTEMPPIN) * (3.3 / 1024.0);
-    float soilTemperature = (voltage - 0.5) * 100;
-    addMeasurement(BODENTSENSOR_ID, soilTemperature);
-    voltage = analogRead(SOILMOISPIN) * (3.3 / 1024.0);
-    float soilMoisture = (voltage * 50) / 3;
-    addMeasurement(BODENFSENSOR_ID, soilMoisture);
-  #endif
-
-  //-----dB(A) Sound Level-----//
-  #ifdef SOUNDLEVELMETER_CONNECTED
-    float v = analogRead(SOUNDMETERPIN) * (3.3 / 1024.0);
-    float decibel = v * 50;
-    addMeasurement(LAUTSTSENSOR_ID, decibel);
-  #endif
-
-  //-----BME680-----//
-  #ifdef BME680_CONNECTED
-    BME.setGasHeater(0, 0);
-    if( BME.performReading()) {
-       addMeasurement(LUFTTESENSOR_ID, BME.temperature-1);
-       addMeasurement(LUFTFESENSOR_ID, BME.humidity);
-       addMeasurement(ATMLUFSENSOR_ID, BME.pressure/100);
-    }
-    BME.setGasHeater(320, 150); // 320*C for 150 ms
-    if( BME.performReading()) {
-       addMeasurement(VOCSENSOR_ID, BME.gas_resistance / 1000.0);
-    }
-  #endif
-
-  //-----Wind speed-----//
-  #ifdef WINDSPEED_CONNECTED
-    float voltageWind = analogRead(WINDSPEEDPIN) * (3.3 / 1024.0);
-    float windspeed = 0.0;
-    if (voltageWind >= 0.018){
-      float poly1 = pow(voltageWind, 3);
-      poly1 = 17.0359801998299 * poly1;
-      float poly2 = pow(voltageWind, 2);
-      poly2 = 47.9908168343362 * poly2;
-      float poly3 = 122.899677524413 * voltageWind;
-      float poly4 = 0.657504127272728;
-      windspeed = poly1 - poly2 + poly3 - poly4;
-      windspeed = windspeed * 0.2777777777777778; //conversion in m/s
-    }
-    addMeasurement(WINDGESENSOR_ID, windspeed);
-  #endif
-
-  //-----CO2-----//
-  #ifdef SCD30_CONNECTED
-    addMeasurement(CO2SENSOR_ID, SCD.getCO2());
-  #endif
-
-  DEBUG(F("Submit values"));
-  submitValues();
-
-  // schedule next round of measurements
-  for (;;) {
-    unsigned long now = millis();
-    unsigned long elapsed = now - start;
 #ifdef DISPLAY128x64_CONNECTED
     display.clearDisplay();
     display.setCursor(0, 0);
@@ -483,114 +403,128 @@ void loop() {
     display.setTextColor(WHITE, BLACK);
     switch (page)
     {
-    case 0:
-      // HDC & BMP
-      display.setTextSize(2);
-      display.setTextColor(BLACK, WHITE);
-      display.println(F("HDC&BMP"));
-      display.setTextColor(WHITE, BLACK);
-      display.println();
-      display.setTextSize(1);
-      display.print(F("Temp:"));
+      case 0:
+        // HDC & BMP
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("HDC&BMP"));
+        display.setTextColor(WHITE, BLACK);
+        display.setTextSize(1);
+        display.print(F("Temp:"));
 #ifdef HDC1080_CONNECTED
-      display.println(HDC.readTemperature());
+        display.println(HDC.readTemperature());
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      display.print(F("Humi:"));
+        display.println();
+        display.print(F("Humi:"));
 #ifdef HDC1080_CONNECTED
-      display.println(HDC.readHumidity());
+        display.println(HDC.readHumidity());
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      display.print(F("Pressure:"));
+        display.println();
+        display.print(F("Press.:"));
 #ifdef BMP280_CONNECTED
-      display.println(BMP.readPressure() / 100);
+        display.println(BMP.readPressure() / 100);
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      break;
-    case 1:
-      // TSL/VEML
-      display.setTextSize(2);
-      display.setTextColor(BLACK, WHITE);
-      display.println(F("TSL&VEML"));
-      display.setTextColor(WHITE, BLACK);
-      display.println();
-      display.setTextSize(1);
-      display.print(F("Lux:"));
+        break;
+      case 1:
+        // TSL/VEML
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("TSL&VEML"));
+        display.setTextColor(WHITE, BLACK);
+        display.println();
+        display.setTextSize(1);
+        display.print(F("Lux:"));
 #ifdef TSL45315_CONNECTED
-      display.println(TSL.readLux());
+        display.println(TSL.readLux());
 #else
-      display.println(F(F("not connected")));
+        display.println(F("not connected")));
 #endif
-      display.print("UV:");
+        display.println();
+        display.print("UV:");
 #ifdef VEML6070_CONNECTED
-      display.println(VEML.getUV());
+        display.println(VEML.getUV());
 #else
-      display.println(F(F("not connected")));
+        display.println(F("not connected")));
 #endif
-      break;
-    case 2:
-      // SMT, SOUND LEVEL , BME
-      display.setTextSize(2);
-      display.setTextColor(BLACK, WHITE);
-      display.println(F("Soil"));
-      display.setTextColor(WHITE, BLACK);
-      display.println();
-      display.setTextSize(1);
-      display.print(F("Soil Temp:"));
+        break;
+      case 2:
+        // SMT, SOUND LEVEL , BME
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("Soil"));
+        display.setTextColor(WHITE, BLACK);
+        display.println();
+        display.setTextSize(1);
+        display.print(F("Temp:"));
 #ifdef SMT50_CONNECTED
-      display.println(soilTemperature);
+        display.println(soilTemperature);
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      display.print(F("Soil moist"));
+        display.println();
+        display.print(F("Moist:"));
 #ifdef SMT50_CONNECTED
-      display.println(soilMoisture);
+        display.println(soilMoisture);
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      display.print(F("SOUND:"));
-#ifdef SOUNDLEVELMETER_CONNECTED
-      display.println(decibel);
-#else
-      display.println(F("not connected"));
-#endif
-      display.print(F("Gas"));
 
-#ifdef BME680_CONNECTED
-      display.println(gasResistance);
-#else
-      display.print(F("not connected"));
-#endif
-      break;
-    case 3:
-      // WINDSPEED SCD30
-      display.setTextSize(2);
-      display.setTextColor(BLACK, WHITE);
-      display.println(F("Wind&SCD30"));
-      display.setTextColor(WHITE, BLACK);
-      display.println();
-      display.setTextSize(1);
-      display.print(F("Windspeed:"));
+        break;
+      case 3:
+        // WINDSPEED SCD30
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("Wind&SCD30"));
+        display.setTextColor(WHITE, BLACK);
+        display.println();
+        display.setTextSize(1);
+        display.print(F("Speed:"));
 #ifdef WINDSPEED_CONNECTED
-      display.println(windspeed);
+        display.println(windspeed);
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      display.print(F("SCD30:"));
+        display.println();
+        display.print(F("SCD30:"));
 #ifdef SCD30_CONNECTED
-      display.println(SCD.getCO2());
+        display.println(SCD.getCO2());
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      break;
+        break;
+      case 4:
+          // SMT, SOUND LEVEL , BME
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("Sound&BME"));
+        display.setTextColor(WHITE, BLACK);
+        display.println();
+        display.setTextSize(1);
+        display.print(F("Sound:"));
+#ifdef SOUNDLEVELMETER_CONNECTED
+        display.println(decibel);
+#else
+        display.println(F("not connected"));
+#endif
+        display.println();
+        display.print(F("Gas:"));
+#ifdef BME680_CONNECTED
+        display.println(gasResistance);
+#else
+        display.print(F("not connected"));
+#endif
+        break;
     }
     display.display();
     if (elapsed >= displayTime)
     {
-      if (page == 3)
+      if (page == 4)
       {
         page = 0;
       }

--- a/templates/homev2_wifi.tpl
+++ b/templates/homev2_wifi.tpl
@@ -526,19 +526,6 @@ void loop() {
 #endif
       break;
     case 2:
-      // SDS
-      display.setTextSize(2);
-      display.setTextColor(BLACK, WHITE);
-      display.println(F("PM10&PM25"));
-      display.setTextColor(WHITE, BLACK);
-      display.println();
-      display.setTextSize(1);
-      display.print(F("PM10:"));
-      display.println(TSL.readLux());
-      display.print(F("PM25:"));
-      display.println(VEML.getUV());
-      break;
-    case 3:
       // SMT, SOUND LEVEL , BME
       display.setTextSize(2);
       display.setTextColor(BLACK, WHITE);
@@ -572,7 +559,7 @@ void loop() {
       display.print(F("not connected"));
 #endif
       break;
-    case 4:
+    case 3:
       // WINDSPEED SCD30
       display.setTextSize(2);
       display.setTextColor(BLACK, WHITE);
@@ -597,7 +584,7 @@ void loop() {
     display.display();
     if (elapsed >= displayTime)
     {
-      if (page == 4)
+      if (page == 3)
       {
         page = 0;
       }

--- a/templates/homev2_wifi.tpl
+++ b/templates/homev2_wifi.tpl
@@ -17,6 +17,8 @@
 #include <SPI.h>
 #include <senseBoxIO.h>
 
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
 #include <Adafruit_Sensor.h>
 #include <Adafruit_HDC1000.h>
 #include <Adafruit_BMP280.h>

--- a/templates/homev2_wifi.tpl
+++ b/templates/homev2_wifi.tpl
@@ -543,14 +543,14 @@ void loop() {
 #ifdef TSL45315_CONNECTED
         display.println(TSL.readLux());
 #else
-        display.println(F("not connected")));
+        display.println(F("not connected"));
 #endif
         display.println();
         display.print("UV:");
 #ifdef VEML6070_CONNECTED
         display.println(VEML.getUV());
 #else
-        display.println(F("not connected")));
+        display.println(F("not connected"));
 #endif
         break;
       case 2:

--- a/templates/homev2_wifi.tpl
+++ b/templates/homev2_wifi.tpl
@@ -67,7 +67,6 @@ static const uint8_t NUM_SENSORS = @@NUM_SENSORS@@;
 // Connected sensors
 @@SENSORS|toDefineWithSuffixPrefixAndKey~,_CONNECTED,sensorType@@
 
-// Display Connected 
 @@DISPLAY_ENABLED|toDefineDisplay@@
 
 // Sensor SENSOR_IDs

--- a/templates/homev2_wifi_feinstaub.tpl
+++ b/templates/homev2_wifi_feinstaub.tpl
@@ -303,6 +303,7 @@ void setup() {
   senseBoxIO.powerI2C(true);
 
 
+  
 #ifdef DISPLAY128x64_CONNECTED
   DEBUG2(F("enable display..."));
   delay(2000);
@@ -321,6 +322,14 @@ void setup() {
   display.setTextSize(2);
   display.display();
   delay(2000);
+  display.clearDisplay();
+  display.setCursor(0, 0);
+  display.setTextSize(1);
+  display.println("Connecting to:");
+  display.println();
+  display.println(ssid);
+  display.setTextSize(1);
+  display.display();
 #endif
 
   // Check WiFi Shield status
@@ -333,6 +342,10 @@ void setup() {
   uint8_t status = WL_IDLE_STATUS;
   // attempt to connect to Wifi network:
   while (status != WL_CONNECTED) {
+    #ifdef DISPLAY128x64_CONNECTED
+    display.print(".");
+    display.display();
+#endif
     DEBUG2(F("Attempting to connect to SSID: "));
     DEBUG(ssid);
     // Connect to WPA/WPA2 network. Change this line if using open or WEP
@@ -379,6 +392,13 @@ void setup() {
     Wire.begin();
     SCD.begin();
   #endif
+  #ifdef DISPLAY128x64_CONNECTED
+  display.clearDisplay();
+  display.setCursor(30, 28);
+  display.setTextSize(2);
+  display.print("Ready!");
+  display.display();
+#endif
   DEBUG(F("Initializing sensors done!"));
   DEBUG(F("Starting loop in 3 seconds."));
   delay(3000);
@@ -386,17 +406,17 @@ void setup() {
 
 void loop() {
   DEBUG(F("Starting new measurement..."));
-    #ifdef DISPLAY128x64_CONNECTED
-    long displayTime = 5000;
-    int page = 0;
-    
-    display.clearDisplay();
-    display.setCursor(0, 0);
-    display.setTextSize(1);
-    display.setTextColor(WHITE, BLACK);
-    display.println("Uploading new measurement... ");
-    display.display(); 
-  #endif
+#ifdef DISPLAY128x64_CONNECTED
+  long displayTime = 5000;
+  int page = 0;
+
+  display.clearDisplay();
+  display.setCursor(0, 0);
+  display.setTextSize(1);
+  display.setTextColor(WHITE, BLACK);
+  display.println("Uploading new measurement... ");
+  display.display();
+#endif
   // capture loop start timestamp
   unsigned long start = millis();
 
@@ -510,52 +530,53 @@ void loop() {
     {
     case 0:
       // HDC & BMP
-      display.setTextSize(2);
-      display.setTextColor(BLACK, WHITE);
-      display.println(F("HDC&BMP"));
-      display.setTextColor(WHITE, BLACK);
-      display.println();
-      display.setTextSize(1);
-      display.print(F("Temp:"));
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("HDC&BMP"));
+        display.setTextColor(WHITE, BLACK);
+        display.setTextSize(1);
+        display.print(F("Temp:"));
 #ifdef HDC1080_CONNECTED
-      display.println(HDC.readTemperature());
+        display.println(HDC.readTemperature());
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      display.print(F("Humi:"));
+        display.println();
+        display.print(F("Humi:"));
 #ifdef HDC1080_CONNECTED
-      display.println(HDC.readHumidity());
+        display.println(HDC.readHumidity());
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      display.print(F("Pressure:"));
+        display.println();
+        display.print(F("Press.:"));
 #ifdef BMP280_CONNECTED
-      display.println(BMP.readPressure() / 100);
+        display.println(BMP.readPressure() / 100);
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      break;
+        break;
     case 1:
-      // TSL/VEML
-      display.setTextSize(2);
-      display.setTextColor(BLACK, WHITE);
-      display.println(F("TSL&VEML"));
-      display.setTextColor(WHITE, BLACK);
-      display.println();
-      display.setTextSize(1);
-      display.print(F("Lux:"));
+        // TSL/VEML
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("TSL&VEML"));
+        display.setTextColor(WHITE, BLACK);
+        display.println();
+        display.setTextSize(1);
+        display.print(F("Lux:"));
 #ifdef TSL45315_CONNECTED
-      display.println(TSL.readLux());
+        display.println(TSL.readLux());
 #else
-      display.println(F(F("not connected")));
+        display.println(F("not connected")));
 #endif
-      display.print("UV:");
+        display.println();
+        display.print("UV:");
 #ifdef VEML6070_CONNECTED
-      display.println(VEML.getUV());
+        display.println(VEML.getUV());
 #else
-      display.println(F(F("not connected")));
+        display.println(F("not connected")));
 #endif
-      break;
     case 2:
       // SDS
       display.setTextSize(2);
@@ -570,65 +591,77 @@ void loop() {
       display.println(pm25);
       break;
     case 3:
-      // SMT, SOUND LEVEL , BME
-      display.setTextSize(2);
-      display.setTextColor(BLACK, WHITE);
-      display.println(F("Soil"));
-      display.setTextColor(WHITE, BLACK);
-      display.println();
-      display.setTextSize(1);
-      display.print(F("Soil Temp:"));
+        // Soil
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("Soil"));
+        display.setTextColor(WHITE, BLACK);
+        display.println();
+        display.setTextSize(1);
+        display.print(F("Temp:"));
 #ifdef SMT50_CONNECTED
-      display.println(soilTemperature);
+        display.println(soilTemperature);
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      display.print(F("Soil moist"));
+        display.println();
+        display.print(F("Moist:"));
 #ifdef SMT50_CONNECTED
-      display.println(soilMoisture);
+        display.println(soilMoisture);
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      display.print(F("SOUND:"));
-#ifdef SOUNDLEVELMETER_CONNECTED
-      display.println(decibel);
-#else
-      display.println(F("not connected"));
-#endif
-      display.print(F("Gas"));
 
-#ifdef BME680_CONNECTED
-      display.println(gasResistance);
-#else
-      display.print(F("not connected"));
-#endif
-      break;
+        break;
     case 4:
-      // WINDSPEED SCD30
-      display.setTextSize(2);
-      display.setTextColor(BLACK, WHITE);
-      display.println(F("Wind&SCD30"));
-      display.setTextColor(WHITE, BLACK);
-      display.println();
-      display.setTextSize(1);
-      display.print(F("Windspeed:"));
+        // WINDSPEED SCD30
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("Wind&SCD30"));
+        display.setTextColor(WHITE, BLACK);
+        display.println();
+        display.setTextSize(1);
+        display.print(F("Speed:"));
 #ifdef WINDSPEED_CONNECTED
-      display.println(windspeed);
+        display.println(windspeed);
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      display.print(F("SCD30:"));
+        display.println();
+        display.print(F("SCD30:"));
 #ifdef SCD30_CONNECTED
-      display.println(SCD.getCO2());
+        display.println(SCD.getCO2());
 #else
-      display.println(F("not connected"));
+        display.println(F("not connected"));
 #endif
-      break;
+        break;
+    case 5:
+    //SOUND LEVEL , BME
+        display.setTextSize(2);
+        display.setTextColor(BLACK, WHITE);
+        display.println(F("Sound&BME"));
+        display.setTextColor(WHITE, BLACK);
+        display.println();
+        display.setTextSize(1);
+        display.print(F("Sound:"));
+#ifdef SOUNDLEVELMETER_CONNECTED
+        display.println(decibel);
+#else
+        display.println(F("not connected"));
+#endif
+        display.println();
+        display.print(F("Gas:"));
+#ifdef BME680_CONNECTED
+        display.println(gasResistance);
+#else
+        display.print(F("not connected"));
+#endif
+        break;
     }
     display.display();
     if (elapsed >= displayTime)
     {
-      if (page == 4)
+      if (page == 5)
       {
         page = 0;
       }

--- a/templates/homev2_wifi_feinstaub.tpl
+++ b/templates/homev2_wifi_feinstaub.tpl
@@ -479,6 +479,7 @@ void loop() {
 
   //-----BME680-----//
   #ifdef BME680_CONNECTED
+    float gasResistance;
     BME.setGasHeater(0, 0);
     if( BME.performReading()) {
        addMeasurement(LUFTTESENSOR_ID, BME.temperature-1);
@@ -487,7 +488,8 @@ void loop() {
     }
     BME.setGasHeater(320, 150); // 320*C for 150 ms
     if( BME.performReading()) {
-       addMeasurement(VOCSENSOR_ID, BME.gas_resistance / 1000.0);
+       gasResistance = BME.gas_resistance / 1000.0
+       addMeasurement(VOCSENSOR_ID, gasResistance);
     }
   #endif
 

--- a/templates/homev2_wifi_feinstaub.tpl
+++ b/templates/homev2_wifi_feinstaub.tpl
@@ -568,14 +568,14 @@ void loop() {
 #ifdef TSL45315_CONNECTED
         display.println(TSL.readLux());
 #else
-        display.println(F("not connected")));
+        display.println(F("not connected"));
 #endif
         display.println();
         display.print("UV:");
 #ifdef VEML6070_CONNECTED
         display.println(VEML.getUV());
 #else
-        display.println(F("not connected")));
+        display.println(F("not connected"));
 #endif
     case 2:
       // SDS

--- a/templates/homev2_wifi_feinstaub.tpl
+++ b/templates/homev2_wifi_feinstaub.tpl
@@ -17,6 +17,8 @@
 #include <SPI.h>
 #include <Wire.h>
 
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
 #include <Adafruit_Sensor.h>
 #include <Adafruit_HDC1000.h>
 #include <Adafruit_BMP280.h>

--- a/templates/homev2_wifi_feinstaub.tpl
+++ b/templates/homev2_wifi_feinstaub.tpl
@@ -70,6 +70,9 @@ static const uint8_t NUM_SENSORS = @@NUM_SENSORS@@;
 // Connected sensors
 @@SENSORS|toDefineWithSuffixPrefixAndKey~,_CONNECTED,sensorType@@
 
+// Display Connected 
+@@DISPLAY_ENABLED|toDefineDisplay@@
+
 // sensor IDs
 @@SENSOR_IDS|toProgmem@@
 

--- a/templates/homev2_wifi_feinstaub.tpl
+++ b/templates/homev2_wifi_feinstaub.tpl
@@ -488,7 +488,7 @@ void loop() {
     }
     BME.setGasHeater(320, 150); // 320*C for 150 ms
     if( BME.performReading()) {
-       gasResistance = BME.gas_resistance / 1000.0
+       gasResistance = BME.gas_resistance / 1000.0;
        addMeasurement(VOCSENSOR_ID, gasResistance);
     }
   #endif

--- a/templates/homev2_wifi_feinstaub.tpl
+++ b/templates/homev2_wifi_feinstaub.tpl
@@ -70,7 +70,6 @@ static const uint8_t NUM_SENSORS = @@NUM_SENSORS@@;
 // Connected sensors
 @@SENSORS|toDefineWithSuffixPrefixAndKey~,_CONNECTED,sensorType@@
 
-// Display Connected 
 @@DISPLAY_ENABLED|toDefineDisplay@@
 
 // sensor IDs

--- a/templates/homev2_wifi_feinstaub.tpl
+++ b/templates/homev2_wifi_feinstaub.tpl
@@ -70,6 +70,8 @@ static const uint8_t NUM_SENSORS = @@NUM_SENSORS@@;
 // Connected sensors
 @@SENSORS|toDefineWithSuffixPrefixAndKey~,_CONNECTED,sensorType@@
 
+// Display enabled 
+// Uncomment the next line to get values of measurements printed on display
 @@DISPLAY_ENABLED|toDefineDisplay@@
 
 // sensor IDs


### PR DESCRIPTION
# Added display to home sketch

  - DIsplay cycles through 5 pages. Each page displays 2 to 3 sensors from the senseBox:home Setup. If a sensor is not connected, i.e. is not defined via #define statements, instead of displaying a value, `not connected` is shown. 

 - A page will be displayed for 5 seconds

- Status messages at the start give indication of state of sensebox, e.g. when connecting to a network the ssid is shown and the current status (connected <=> not connected) is shown. 
