### PR TITLE
Update variable naming for sensor ids

### DIFF
--- a/arduino-test/build-sketches.js
+++ b/arduino-test/build-sketches.js
@@ -7,7 +7,7 @@ const SketchTemplater = require('../src');
 
 const sketchTemplater = new SketchTemplater('test.ingress.domain');
 
-const boxStub = function(model) {
+const boxStub = function (model) {
   return {
     _id: '59479ed5a4ad5900112d8dec',
     name: 'Teststation',

--- a/src/transformers.js
+++ b/src/transformers.js
@@ -8,8 +8,8 @@ module.exports = {
   },
   toDefine(sensors) {
     const output = [];
-    for (const [i, { _id, title }] of sensors.entries()) {
-      output.push(dedent`// ${title}
+    for (const [i, { _id, title, sensorType }] of sensors.entries()) {
+      output.push(dedent`// ${title} - ${sensorType}
                          #define SENSOR${i + 1}_ID "${_id}"`);
     }
 
@@ -19,7 +19,7 @@ module.exports = {
     const output = [];
     for (const [, sensor] of sensors.entries()) {
       const value = sensor[key].replace(/\s+/g, '');
-      output.push(dedent`// ${sensor.title}
+      output.push(dedent`// ${sensor.title} - ${sensor.sensorType}
                          #define ${prefix}${value.toUpperCase()}${suffix}`);
     }
 
@@ -27,12 +27,12 @@ module.exports = {
   },
   toProgmem(sensors) {
     const output = [];
-    for (const { _id, title } of sensors) {
-      output.push(dedent`// ${title}
-                         const char ${title
-                           .toUpperCase()
-                           .replace(/[^A-Z0-9]+/g, '')
-                           .slice(0, 6)}SENSOR_ID[] PROGMEM = "${_id}";`);
+    for (const { _id, title, sensorType } of sensors) {
+      output.push(dedent`// ${title} - ${sensorType}
+                         const char ${sensorType.toUpperCase()}_${title
+        .toUpperCase()
+        .replace(/[^A-Z0-9]+/g, '')
+        .slice(0, 6)}SENSOR_ID[] PROGMEM = "${_id}";`);
     }
 
     return output.join('\r\n');
@@ -65,17 +65,16 @@ module.exports = {
       chunks = chunks.reverse();
     }
 
-    return `{${chunks.map(c => ` 0x${c}`)} }`;
+    return `{${chunks.map((c) => ` 0x${c}`)} }`;
   },
-  toDefineDisplay(display){
+  toDefineDisplay(display) {
     const output = [];
-    if(display === 'true'){
+    if (display === 'true') {
       output.push(`#define DISPLAY128x64_CONNECTED`);
-    }
-    else{
+    } else {
       output.push(`//#define DISPLAY128x64_CONNECTED`);
     }
 
-    return output.join('\r\n');    
+    return output.join('\r\n');
   }
 };

--- a/src/transformers.js
+++ b/src/transformers.js
@@ -37,6 +37,18 @@ module.exports = {
 
     return output.join('\r\n');
   },
+  toProgmemWithoutPrefix(sensors) {
+    const output = [];
+    for (const { _id, title } of sensors) {
+      output.push(dedent`// ${title}
+                         const char ${title
+                           .toUpperCase()
+                           .replace(/[^A-Z0-9]+/g, '')
+                           .slice(0, 6)}SENSOR_ID[] PROGMEM = "${_id}";`);
+    }
+
+    return output.join('\r\n');
+  },
   digitalPortToPortNumber(port, offset = 0) {
     let portNumber = 0;
     switch (port) {

--- a/templates/home_ethernet.tpl
+++ b/templates/home_ethernet.tpl
@@ -201,9 +201,9 @@ void loop() {
   unsigned long start = millis();
 
   // read measurements from sensors
-  addMeasurement(TEMPERSENSOR_ID, HDC.getTemp());
+  addMeasurement(HDC1080_TEMPERSENSOR_ID, HDC.getTemp());
   delay(200);
-  addMeasurement(RELLUFSENSOR_ID, HDC.getHumi());
+  addMeasurement(HDC1080_RELLUFSENSOR_ID, HDC.getHumi());
 
   double tempBaro, pressure;
   char result;
@@ -211,11 +211,11 @@ void loop() {
   if (result != 0) {
     delay(result);
     result = BMP.getTemperatureAndPressure(tempBaro, pressure);
-    addMeasurement(LUFTDRSENSOR_ID, pressure);
+    addMeasurement(BMP280_LUFTDRSENSOR_ID, pressure);
   }
 
-  addMeasurement(BELEUCSENSOR_ID, TSL.readLux());
-  addMeasurement(UVINTESENSOR_ID, VEML.getUV());
+  addMeasurement(TSL45315_BELEUCSENSOR_ID, TSL.readLux());
+  addMeasurement(VEML6070_UVINTESENSOR_ID, VEML.getUV());
 
   submitValues();
 

--- a/templates/home_ethernet.tpl
+++ b/templates/home_ethernet.tpl
@@ -42,7 +42,7 @@ const char SENSEBOX_ID[] PROGMEM = "@@SENSEBOX_ID@@";
 static const uint8_t NUM_SENSORS = @@NUM_SENSORS@@;
 
 // sensor IDs
-@@SENSOR_IDS|toProgmem@@
+@@SENSOR_IDS|toProgmemWithoutPrefix@@
 
 //Configure static IP setup (only needed if DHCP is disabled)
 IPAddress myIp(192, 168, 0, 42);
@@ -201,9 +201,9 @@ void loop() {
   unsigned long start = millis();
 
   // read measurements from sensors
-  addMeasurement(HDC1080_TEMPERSENSOR_ID, HDC.getTemp());
+  addMeasurement(TEMPERSENSOR_ID, HDC.getTemp());
   delay(200);
-  addMeasurement(HDC1080_RELLUFSENSOR_ID, HDC.getHumi());
+  addMeasurement(RELLUFSENSOR_ID, HDC.getHumi());
 
   double tempBaro, pressure;
   char result;
@@ -211,11 +211,11 @@ void loop() {
   if (result != 0) {
     delay(result);
     result = BMP.getTemperatureAndPressure(tempBaro, pressure);
-    addMeasurement(BMP280_LUFTDRSENSOR_ID, pressure);
+    addMeasurement(LUFTDRSENSOR_ID, pressure);
   }
 
-  addMeasurement(TSL45315_BELEUCSENSOR_ID, TSL.readLux());
-  addMeasurement(VEML6070_UVINTESENSOR_ID, VEML.getUV());
+  addMeasurement(BELEUCSENSOR_ID, TSL.readLux());
+  addMeasurement(UVINTESENSOR_ID, VEML.getUV());
 
   submitValues();
 

--- a/templates/home_ethernet.tpl
+++ b/templates/home_ethernet.tpl
@@ -90,7 +90,7 @@ measurement measurements[NUM_SENSORS];
 uint8_t num_measurements = 0;
 
 // buffer for sprintf
-char buffer[150];
+char buffer[750];
 
 void addMeasurement(const char *sensorId, float value) {
   measurements[num_measurements].sensorId = sensorId;

--- a/templates/home_ethernet_feinstaub.tpl
+++ b/templates/home_ethernet_feinstaub.tpl
@@ -203,9 +203,9 @@ void loop() {
   unsigned long start = millis();
 
   // read measurements from sensors
-  addMeasurement(TEMPERSENSOR_ID, HDC.getTemp());
+  addMeasurement(HDC1080_TEMPERSENSOR_ID, HDC.getTemp());
   delay(200);
-  addMeasurement(RELLUFSENSOR_ID, HDC.getHumi());
+  addMeasurement(HDC1080_RELLUFSENSOR_ID, HDC.getHumi());
 
   double tempBaro, pressure;
   char result;
@@ -213,19 +213,19 @@ void loop() {
   if (result != 0) {
     delay(result);
     result = BMP.getTemperatureAndPressure(tempBaro, pressure);
-    addMeasurement(LUFTDRSENSOR_ID, pressure);
+    addMeasurement(BMP280_LUFTDRSENSOR_ID, pressure);
   }
 
-  addMeasurement(BELEUCSENSOR_ID, TSL.readLux());
-  addMeasurement(UVINTESENSOR_ID, VEML.getUV());
+  addMeasurement(TSL45315_BELEUCSENSOR_ID, TSL.readLux());
+  addMeasurement(VEML6070_UVINTESENSOR_ID, VEML.getUV());
 
   uint8_t attempt = 0;
   float pm10, pm25;
   while (attempt < 5) {
     bool error = my_sds.read(&pm25, &pm10);
     if (!error) {
-      addMeasurement(PM10SENSOR_ID, pm10);
-      addMeasurement(PM25SENSOR_ID, pm25);
+      addMeasurement(SDS011_PM10SENSOR_ID, pm10);
+      addMeasurement(SDS011_PM25SENSOR_ID, pm25);
       break;
     }
     attempt++;

--- a/templates/home_ethernet_feinstaub.tpl
+++ b/templates/home_ethernet_feinstaub.tpl
@@ -92,7 +92,7 @@ measurement measurements[NUM_SENSORS];
 uint8_t num_measurements = 0;
 
 // buffer for sprintf
-char buffer[150];
+char buffer[750];
 
 void addMeasurement(const char *sensorId, float value) {
   measurements[num_measurements].sensorId = sensorId;

--- a/templates/home_ethernet_feinstaub.tpl
+++ b/templates/home_ethernet_feinstaub.tpl
@@ -42,7 +42,7 @@ const char SENSEBOX_ID[] PROGMEM = "@@SENSEBOX_ID@@";
 static const uint8_t NUM_SENSORS = @@NUM_SENSORS@@;
 
 // sensor IDs
-@@SENSOR_IDS|toProgmem@@
+@@SENSOR_IDS|toProgmemWithoutPrefix@@
 
 //Configure static IP setup (only needed if DHCP is disabled)
 IPAddress myIp(192, 168, 0, 42);
@@ -203,9 +203,9 @@ void loop() {
   unsigned long start = millis();
 
   // read measurements from sensors
-  addMeasurement(HDC1080_TEMPERSENSOR_ID, HDC.getTemp());
+  addMeasurement(TEMPERSENSOR_ID, HDC.getTemp());
   delay(200);
-  addMeasurement(HDC1080_RELLUFSENSOR_ID, HDC.getHumi());
+  addMeasurement(RELLUFSENSOR_ID, HDC.getHumi());
 
   double tempBaro, pressure;
   char result;
@@ -213,19 +213,19 @@ void loop() {
   if (result != 0) {
     delay(result);
     result = BMP.getTemperatureAndPressure(tempBaro, pressure);
-    addMeasurement(BMP280_LUFTDRSENSOR_ID, pressure);
+    addMeasurement(LUFTDRSENSOR_ID, pressure);
   }
 
-  addMeasurement(TSL45315_BELEUCSENSOR_ID, TSL.readLux());
-  addMeasurement(VEML6070_UVINTESENSOR_ID, VEML.getUV());
+  addMeasurement(BELEUCSENSOR_ID, TSL.readLux());
+  addMeasurement(UVINTESENSOR_ID, VEML.getUV());
 
   uint8_t attempt = 0;
   float pm10, pm25;
   while (attempt < 5) {
     bool error = my_sds.read(&pm25, &pm10);
     if (!error) {
-      addMeasurement(SDS011_PM10SENSOR_ID, pm10);
-      addMeasurement(SDS011_PM25SENSOR_ID, pm25);
+      addMeasurement(PM10SENSOR_ID, pm10);
+      addMeasurement(PM25SENSOR_ID, pm25);
       break;
     }
     attempt++;

--- a/templates/home_wifi.tpl
+++ b/templates/home_wifi.tpl
@@ -44,7 +44,7 @@ const char SENSEBOX_ID[] PROGMEM = "@@SENSEBOX_ID@@";
 static const uint8_t NUM_SENSORS = @@NUM_SENSORS@@;
 
 // sensor IDs
-@@SENSOR_IDS|toProgmem@@
+@@SENSOR_IDS|toProgmemWithoutPrefix@@
 
 // Uncomment the next line to get debugging messages printed on the Serial port
 // Do not leave this enabled for long time use
@@ -219,9 +219,9 @@ void loop() {
   unsigned long start = millis();
 
   // read measurements from sensors
-  addMeasurement(HDC1080_TEMPERSENSOR_ID, HDC.getTemp());
+  addMeasurement(TEMPERSENSOR_ID, HDC.getTemp());
   delay(200);
-  addMeasurement(HDC1080_RELLUFSENSOR_ID, HDC.getHumi());
+  addMeasurement(RELLUFSENSOR_ID, HDC.getHumi());
 
   double tempBaro, pressure;
   char result;
@@ -229,11 +229,11 @@ void loop() {
   if (result != 0) {
     delay(result);
     result = BMP.getTemperatureAndPressure(tempBaro, pressure);
-    addMeasurement(BMP280_LUFTDRSENSOR_ID, pressure);
+    addMeasurement(LUFTDRSENSOR_ID, pressure);
   }
 
-  addMeasurement(TSL45315_BELEUCSENSOR_ID, TSL.readLux());
-  addMeasurement(VEML6070_UVINTESENSOR_ID, VEML.getUV());
+  addMeasurement(BELEUCSENSOR_ID, TSL.readLux());
+  addMeasurement(UVINTESENSOR_ID, VEML.getUV());
 
   submitValues();
 

--- a/templates/home_wifi.tpl
+++ b/templates/home_wifi.tpl
@@ -219,9 +219,9 @@ void loop() {
   unsigned long start = millis();
 
   // read measurements from sensors
-  addMeasurement(TEMPERSENSOR_ID, HDC.getTemp());
+  addMeasurement(HDC1080_TEMPERSENSOR_ID, HDC.getTemp());
   delay(200);
-  addMeasurement(RELLUFSENSOR_ID, HDC.getHumi());
+  addMeasurement(HDC1080_RELLUFSENSOR_ID, HDC.getHumi());
 
   double tempBaro, pressure;
   char result;
@@ -229,11 +229,11 @@ void loop() {
   if (result != 0) {
     delay(result);
     result = BMP.getTemperatureAndPressure(tempBaro, pressure);
-    addMeasurement(LUFTDRSENSOR_ID, pressure);
+    addMeasurement(BMP280_LUFTDRSENSOR_ID, pressure);
   }
 
-  addMeasurement(BELEUCSENSOR_ID, TSL.readLux());
-  addMeasurement(UVINTESENSOR_ID, VEML.getUV());
+  addMeasurement(TSL45315_BELEUCSENSOR_ID, TSL.readLux());
+  addMeasurement(VEML6070_UVINTESENSOR_ID, VEML.getUV());
 
   submitValues();
 

--- a/templates/home_wifi.tpl
+++ b/templates/home_wifi.tpl
@@ -86,7 +86,7 @@ measurement measurements[NUM_SENSORS];
 uint8_t num_measurements = 0;
 
 // buffer for sprintf
-char buffer[750];
+char buffer[500];
 
 void addMeasurement(const char *sensorId, float value) {
   measurements[num_measurements].sensorId = sensorId;

--- a/templates/home_wifi.tpl
+++ b/templates/home_wifi.tpl
@@ -86,7 +86,7 @@ measurement measurements[NUM_SENSORS];
 uint8_t num_measurements = 0;
 
 // buffer for sprintf
-char buffer[150];
+char buffer[750];
 
 void addMeasurement(const char *sensorId, float value) {
   measurements[num_measurements].sensorId = sensorId;

--- a/templates/home_wifi_feinstaub.tpl
+++ b/templates/home_wifi_feinstaub.tpl
@@ -221,9 +221,9 @@ void loop() {
   unsigned long start = millis();
 
   // read measurements from sensors
-  addMeasurement(TEMPERSENSOR_ID, HDC.getTemp());
+  addMeasurement(HDC1080_TEMPERSENSOR_ID, HDC.getTemp());
   delay(200);
-  addMeasurement(RELLUFSENSOR_ID, HDC.getHumi());
+  addMeasurement(HDC1080_RELLUFSENSOR_ID, HDC.getHumi());
 
   double tempBaro, pressure;
   char result;
@@ -231,19 +231,19 @@ void loop() {
   if (result != 0) {
     delay(result);
     result = BMP.getTemperatureAndPressure(tempBaro, pressure);
-    addMeasurement(LUFTDRSENSOR_ID, pressure);
+    addMeasurement(BMP280_LUFTDRSENSOR_ID, pressure);
   }
 
-  addMeasurement(BELEUCSENSOR_ID, TSL.readLux());
-  addMeasurement(UVINTESENSOR_ID, VEML.getUV());
+  addMeasurement(TSL45315_BELEUCSENSOR_ID, TSL.readLux());
+  addMeasurement(VEML6070_UVINTESENSOR_ID, VEML.getUV());
 
   uint8_t attempt = 0;
   float pm10, pm25;
   while (attempt < 5) {
     bool error = my_sds.read(&pm25, &pm10);
     if (!error) {
-      addMeasurement(PM10SENSOR_ID, pm10);
-      addMeasurement(PM25SENSOR_ID, pm25);
+      addMeasurement(SDS011_PM10SENSOR_ID, pm10);
+      addMeasurement(SDS011_PM25SENSOR_ID, pm25);
       break;
     }
     attempt++;

--- a/templates/home_wifi_feinstaub.tpl
+++ b/templates/home_wifi_feinstaub.tpl
@@ -88,7 +88,7 @@ measurement measurements[NUM_SENSORS];
 uint8_t num_measurements = 0;
 
 // buffer for sprintf
-char buffer[750];
+char buffer[500];
 
 void addMeasurement(const char *sensorId, float value) {
   measurements[num_measurements].sensorId = sensorId;

--- a/templates/home_wifi_feinstaub.tpl
+++ b/templates/home_wifi_feinstaub.tpl
@@ -88,7 +88,7 @@ measurement measurements[NUM_SENSORS];
 uint8_t num_measurements = 0;
 
 // buffer for sprintf
-char buffer[150];
+char buffer[750];
 
 void addMeasurement(const char *sensorId, float value) {
   measurements[num_measurements].sensorId = sensorId;

--- a/templates/home_wifi_feinstaub.tpl
+++ b/templates/home_wifi_feinstaub.tpl
@@ -44,7 +44,7 @@ const char SENSEBOX_ID[] PROGMEM = "@@SENSEBOX_ID@@";
 static const uint8_t NUM_SENSORS = @@NUM_SENSORS@@;
 
 // sensor IDs
-@@SENSOR_IDS|toProgmem@@
+@@SENSOR_IDS|toProgmemWithoutPrefix@@
 
 // Uncomment the next line to get debugging messages printed on the Serial port
 // Do not leave this enabled for long time use
@@ -221,9 +221,9 @@ void loop() {
   unsigned long start = millis();
 
   // read measurements from sensors
-  addMeasurement(HDC1080_TEMPERSENSOR_ID, HDC.getTemp());
+  addMeasurement(TEMPERSENSOR_ID, HDC.getTemp());
   delay(200);
-  addMeasurement(HDC1080_RELLUFSENSOR_ID, HDC.getHumi());
+  addMeasurement(RELLUFSENSOR_ID, HDC.getHumi());
 
   double tempBaro, pressure;
   char result;
@@ -231,19 +231,19 @@ void loop() {
   if (result != 0) {
     delay(result);
     result = BMP.getTemperatureAndPressure(tempBaro, pressure);
-    addMeasurement(BMP280_LUFTDRSENSOR_ID, pressure);
+    addMeasurement(LUFTDRSENSOR_ID, pressure);
   }
 
-  addMeasurement(TSL45315_BELEUCSENSOR_ID, TSL.readLux());
-  addMeasurement(VEML6070_UVINTESENSOR_ID, VEML.getUV());
+  addMeasurement(BELEUCSENSOR_ID, TSL.readLux());
+  addMeasurement(UVINTESENSOR_ID, VEML.getUV());
 
   uint8_t attempt = 0;
   float pm10, pm25;
   while (attempt < 5) {
     bool error = my_sds.read(&pm25, &pm10);
     if (!error) {
-      addMeasurement(SDS011_PM10SENSOR_ID, pm10);
-      addMeasurement(SDS011_PM25SENSOR_ID, pm25);
+      addMeasurement(PM10SENSOR_ID, pm10);
+      addMeasurement(PM25SENSOR_ID, pm25);
       break;
     }
     attempt++;

--- a/templates/homev2_ethernet.tpl
+++ b/templates/homev2_ethernet.tpl
@@ -378,7 +378,7 @@ void setup() {
   delay(3000);
 
   timeClient.begin();
-  ArduinoBearSSL.onGetTime(getTime);  
+  ArduinoBearSSL.onGetTime(getTime);
 
 }
 
@@ -391,56 +391,56 @@ void loop() {
   //-----Temperature-----//
   //-----Humidity-----//
   #ifdef HDC1080_CONNECTED
-    addMeasurement(TEMPERSENSOR_ID, HDC.readTemperature());
+    addMeasurement(HDC1080_TEMPERSENSOR_ID, HDC.readTemperature());
     delay(200);
-    addMeasurement(RELLUFSENSOR_ID, HDC.readHumidity());
+    addMeasurement(HDC1080_RELLUFSENSOR_ID, HDC.readHumidity());
   #endif
 
   //-----Pressure-----//
   #ifdef BMP280_CONNECTED
     float pressure;
     pressure = BMP.readPressure()/100;
-    addMeasurement(LUFTDRSENSOR_ID, pressure);
+    addMeasurement(BMP280_LUFTDRSENSOR_ID, pressure);
   #endif
 
   //-----Lux-----//
   #ifdef TSL45315_CONNECTED
-    addMeasurement(BELEUCSENSOR_ID, Lightsensor_getIlluminance());
+    addMeasurement(TSL45315_BELEUCSENSOR_ID, Lightsensor_getIlluminance());
   #endif
 
   //-----UV intensity-----//
   #ifdef VEML6070_CONNECTED
-    addMeasurement(UVINTESENSOR_ID, VEML.getUV());
+    addMeasurement(VEML6070_UVINTESENSOR_ID, VEML.getUV());
   #endif
 
   //-----Soil Temperature & Moisture-----//
   #ifdef SMT50_CONNECTED
     float voltage = analogRead(SOILTEMPPIN) * (3.3 / 1024.0);
     float soilTemperature = (voltage - 0.5) * 100;
-    addMeasurement(BODENTSENSOR_ID, soilTemperature);
+    addMeasurement(SMT50_BODENTSENSOR_ID, soilTemperature);
     voltage = analogRead(SOILMOISPIN) * (3.3 / 1024.0);
     float soilMoisture = (voltage * 50) / 3;
-    addMeasurement(BODENFSENSOR_ID, soilMoisture);
+    addMeasurement(SMT50_BODENFSENSOR_ID, soilMoisture);
   #endif
 
   //-----dB(A) Sound Level-----//
   #ifdef SOUNDLEVELMETER_CONNECTED
     float v = analogRead(SOUNDMETERPIN) * (3.3 / 1024.0);
     float decibel = v * 50;
-    addMeasurement(LAUTSTSENSOR_ID, decibel);
+    addMeasurement(SOUNDLEVELMETER_LAUTSTSENSOR_ID, decibel);
   #endif
 
   //-----BME680-----//
   #ifdef BME680_CONNECTED
     BME.setGasHeater(0, 0);
     if( BME.performReading()) {
-       addMeasurement(LUFTTESENSOR_ID, BME.temperature-1);
-       addMeasurement(LUFTFESENSOR_ID, BME.humidity);
-       addMeasurement(ATMLUFSENSOR_ID, BME.pressure/100);
+       addMeasurement(BME680_LUFTTESENSOR_ID, BME.temperature-1);
+       addMeasurement(BME680_LUFTFESENSOR_ID, BME.humidity);
+       addMeasurement(BME680_ATMLUFSENSOR_ID, BME.pressure/100);
     }
     BME.setGasHeater(320, 150); // 320*C for 150 ms
     if( BME.performReading()) {
-       addMeasurement(VOCSENSOR_ID, BME.gas_resistance / 1000.0);
+       addMeasurement(BME680_VOCSENSOR_ID, BME.gas_resistance / 1000.0);
     }
   #endif
 
@@ -458,19 +458,19 @@ void loop() {
       windspeed = poly1 - poly2 + poly3 - poly4;
       windspeed = windspeed * 0.2777777777777778; //conversion in m/s
     }
-    addMeasurement(WINDGESENSOR_ID, windspeed);
+    addMeasurement(WINDSPEED_WINDGESENSOR_ID, windspeed);
   #endif
 
   //-----CO2-----//
   #ifdef SCD30_CONNECTED
-    addMeasurement(CO2SENSOR_ID, SCD.getCO2());
+    addMeasurement(SCD30_CO2SENSOR_ID, SCD.getCO2());
   #endif
 
   //-----DPS310 Pressure-----//
   #ifdef DPS310_CONNECTED
     sensors_event_t temp_event, pressure_event;
     dps.getEvents(&temp_event, &pressure_event);
-    addMeasurement(DPS310SENSOR_ID, pressure_event.pressure);
+    addMeasurement(DPS310_LUFTDRSENSOR_ID, pressure_event.pressure);
   #endif
 
   DEBUG(F("submit values"));

--- a/templates/homev2_ethernet_feinstaub.tpl
+++ b/templates/homev2_ethernet_feinstaub.tpl
@@ -388,7 +388,7 @@ void setup() {
   delay(3000);
 
   timeClient.begin();
-  ArduinoBearSSL.onGetTime(getTime);  
+  ArduinoBearSSL.onGetTime(getTime);
 }
 
 void loop() {
@@ -400,26 +400,26 @@ void loop() {
   //-----Temperature-----//
   //-----Humidity-----//
   #ifdef HDC1080_CONNECTED
-    addMeasurement(TEMPERSENSOR_ID, HDC.readTemperature());
+    addMeasurement(HDC1080_TEMPERSENSOR_ID, HDC.readTemperature());
     delay(200);
-    addMeasurement(RELLUFSENSOR_ID, HDC.readHumidity());
+    addMeasurement(HDC1080_RELLUFSENSOR_ID, HDC.readHumidity());
   #endif
 
   //-----Pressure-----//
   #ifdef BMP280_CONNECTED
     float pressure;
     pressure = BMP.readPressure()/100;
-    addMeasurement(LUFTDRSENSOR_ID, pressure);
+    addMeasurement(BMP280_LUFTDRSENSOR_ID, pressure);
   #endif
 
   //-----Lux-----//
   #ifdef TSL45315_CONNECTED
-    addMeasurement(BELEUCSENSOR_ID, Lightsensor_getIlluminance());
+    addMeasurement(TSL45315_BELEUCSENSOR_ID, Lightsensor_getIlluminance());
   #endif
 
   //-----UV intensity-----//
   #ifdef VEML6070_CONNECTED
-    addMeasurement(UVINTESENSOR_ID, VEML.getUV());
+    addMeasurement(VEML6070_UVINTESENSOR_ID, VEML.getUV());
   #endif
 
   //-----PM-----//
@@ -429,8 +429,8 @@ void loop() {
     while (attempt < 5) {
       bool error = SDS.read(&pm25, &pm10);
       if (!error) {
-        addMeasurement(PM10SENSOR_ID, pm10);
-        addMeasurement(PM25SENSOR_ID, pm25);
+        addMeasurement(SDS011_PM10SENSOR_ID, pm10);
+        addMeasurement(SDS011_PM25SENSOR_ID, pm25);
         break;
       }
       attempt++;
@@ -441,30 +441,30 @@ void loop() {
   #ifdef SMT50_CONNECTED
     float voltage = analogRead(SOILTEMPPIN) * (3.3 / 1024.0);
     float soilTemperature = (voltage - 0.5) * 100;
-    addMeasurement(BODENTSENSOR_ID, soilTemperature);
+    addMeasurement(SMT50_BODENTSENSOR_ID, soilTemperature);
     voltage = analogRead(SOILMOISPIN) * (3.3 / 1024.0);
     float soilMoisture = (voltage * 50) / 3;
-    addMeasurement(BODENFSENSOR_ID, soilMoisture);
+    addMeasurement(SMT50_BODENFSENSOR_ID, soilMoisture);
   #endif
 
   //-----dB(A) Sound Level-----//
   #ifdef SOUNDLEVELMETER_CONNECTED
     float v = analogRead(SOUNDMETERPIN) * (3.3 / 1024.0);
     float decibel = v * 50;
-    addMeasurement(LAUTSTSENSOR_ID, decibel);
+    addMeasurement(SOUNDLEVELMETER_LAUTSTSENSOR_ID, decibel);
   #endif
 
   //-----BME680-----//
   #ifdef BME680_CONNECTED
     BME.setGasHeater(0, 0);
     if( BME.performReading()) {
-       addMeasurement(LUFTTESENSOR_ID, BME.temperature-1);
-       addMeasurement(LUFTFESENSOR_ID, BME.humidity);
-       addMeasurement(ATMLUFSENSOR_ID, BME.pressure/100);
+       addMeasurement(BME680_LUFTTESENSOR_ID, BME.temperature-1);
+       addMeasurement(BME680_LUFTFESENSOR_ID, BME.humidity);
+       addMeasurement(BME680_ATMLUFSENSOR_ID, BME.pressure/100);
     }
     BME.setGasHeater(320, 150); // 320*C for 150 ms
     if( BME.performReading()) {
-       addMeasurement(VOCSENSOR_ID, BME.gas_resistance / 1000.0);
+       addMeasurement(BME680_VOCSENSOR_ID, BME.gas_resistance / 1000.0);
     }
   #endif
 
@@ -482,19 +482,19 @@ void loop() {
       windspeed = poly1 - poly2 + poly3 - poly4;
       windspeed = windspeed * 0.2777777777777778; //conversion in m/s
     }
-    addMeasurement(WINDGESENSOR_ID, windspeed);
+    addMeasurement(WINDSPEED_WINDGESENSOR_ID, windspeed);
   #endif
 
   //-----CO2-----//
   #ifdef SCD30_CONNECTED
-    addMeasurement(CO2SENSOR_ID, SCD.getCO2());
+    addMeasurement(SCD30_CO2SENSOR_ID, SCD.getCO2());
   #endif
 
   //-----DPS310 Pressure-----//
   #ifdef DPS310_CONNECTED
     sensors_event_t temp_event, pressure_event;
     dps.getEvents(&temp_event, &pressure_event);
-    addMeasurement(DPS310SENSOR_ID, pressure_event.pressure);
+    addMeasurement(DPS310_LUFTDRSENSOR_ID, pressure_event.pressure);
   #endif
 
   DEBUG(F("submit values"));

--- a/templates/homev2_wifi.tpl
+++ b/templates/homev2_wifi.tpl
@@ -477,7 +477,7 @@ void loop() {
 #ifdef SMT50_CONNECTED
   float voltage = analogRead(SOILTEMPPIN) * (3.3 / 1024.0);
   float soilTemperature = (voltage - 0.5) * 100;
-  addMeasurement(BODENTSENSOR_ID, soilTemperature);
+  addMeasurement(SMT50_BODENTSENSOR_ID, soilTemperature);
   voltage = analogRead(SOILMOISPIN) * (3.3 / 1024.0);
   float soilMoisture = (voltage * 50) / 3;
   addMeasurement(SMT50_BODENFSENSOR_ID, soilMoisture);

--- a/templates/homev2_wifi.tpl
+++ b/templates/homev2_wifi.tpl
@@ -451,26 +451,26 @@ void loop() {
   //-----Temperature-----//
   //-----Humidity-----//
 #ifdef HDC1080_CONNECTED
-  addMeasurement(TEMPERSENSOR_ID, HDC.readTemperature());
+  addMeasurement(HDC1080_TEMPERSENSOR_ID, HDC.readTemperature());
   delay(200);
-  addMeasurement(RELLUFSENSOR_ID, HDC.readHumidity());
+  addMeasurement(HDC1080_RELLUFSENSOR_ID, HDC.readHumidity());
 #endif
 
   //-----Pressure-----//
 #ifdef BMP280_CONNECTED
   float pressure;
   pressure = BMP.readPressure() / 100;
-  addMeasurement(LUFTDRSENSOR_ID, pressure);
+  addMeasurement(BMP280_LUFTDRSENSOR_ID, pressure);
 #endif
 
   //-----Lux-----//
 #ifdef TSL45315_CONNECTED
-  addMeasurement(BELEUCSENSOR_ID, Lightsensor_getIlluminance());
+  addMeasurement(TSL45315_BELEUCSENSOR_ID, Lightsensor_getIlluminance());
 #endif
 
   //-----UV intensity-----//
 #ifdef VEML6070_CONNECTED
-  addMeasurement(UVINTESENSOR_ID, VEML.getUV());
+  addMeasurement(VEML6070_UVINTESENSOR_ID, VEML.getUV());
 #endif
 
   //-----Soil Temperature & Moisture-----//
@@ -480,14 +480,14 @@ void loop() {
   addMeasurement(BODENTSENSOR_ID, soilTemperature);
   voltage = analogRead(SOILMOISPIN) * (3.3 / 1024.0);
   float soilMoisture = (voltage * 50) / 3;
-  addMeasurement(BODENFSENSOR_ID, soilMoisture);
+  addMeasurement(SMT50_BODENFSENSOR_ID, soilMoisture);
 #endif
 
   //-----dB(A) Sound Level-----//
 #ifdef SOUNDLEVELMETER_CONNECTED
   float v = analogRead(SOUNDMETERPIN) * (3.3 / 1024.0);
   float decibel = v * 50;
-  addMeasurement(LAUTSTSENSOR_ID, decibel);
+  addMeasurement(SOUNDLEVELMETER_LAUTSTSENSOR_ID, decibel);
 #endif
 
   //-----BME680-----//
@@ -495,14 +495,14 @@ void loop() {
   BME.setGasHeater(0, 0);
   float gasResistance;
   if ( BME.performReading()) {
-    addMeasurement(LUFTTESENSOR_ID, BME.temperature - 1);
-    addMeasurement(LUFTFESENSOR_ID, BME.humidity);
-    addMeasurement(ATMLUFSENSOR_ID, BME.pressure / 100);
+    addMeasurement(BME680_LUFTTESENSOR_ID, BME.temperature - 1);
+    addMeasurement(BME680_LUFTFESENSOR_ID, BME.humidity);
+    addMeasurement(BME680_ATMLUFSENSOR_ID, BME.pressure / 100);
   }
   BME.setGasHeater(320, 150); // 320*C for 150 ms
   if ( BME.performReading()) {
       gasResistance = BME.gas_resistance / 1000.0;
-       addMeasurement(VOCSENSOR_ID, gasResistance);
+       addMeasurement(BME680_VOCSENSOR_ID, gasResistance);
   }
 #endif
 
@@ -520,19 +520,19 @@ void loop() {
     windspeed = poly1 - poly2 + poly3 - poly4;
     windspeed = windspeed * 0.2777777777777778; //conversion in m/s
   }
-  addMeasurement(WINDGESENSOR_ID, windspeed);
+  addMeasurement(WINDSPEED_WINDGESENSOR_ID, windspeed);
 #endif
 
   //-----CO2-----//
 #ifdef SCD30_CONNECTED
-  addMeasurement(CO2SENSOR_ID, SCD.getCO2());
+  addMeasurement(SCD30_CO2SENSOR_ID, SCD.getCO2());
 #endif
 
   //-----DPS310 Pressure-----//
   #ifdef DPS310_CONNECTED
     sensors_event_t temp_event, pressure_event;
     dps.getEvents(&temp_event, &pressure_event);
-    addMeasurement(DPS310SENSOR_ID, pressure_event.pressure);
+    addMeasurement(DPS310_LUFTDRSENSOR_ID, pressure_event.pressure);
   #endif
 
   DEBUG(F("Submit values"));

--- a/templates/homev2_wifi_feinstaub.tpl
+++ b/templates/homev2_wifi_feinstaub.tpl
@@ -460,26 +460,26 @@ void loop() {
   //-----Temperature-----//
   //-----Humidity-----//
   #ifdef HDC1080_CONNECTED
-    addMeasurement(TEMPERSENSOR_ID, HDC.readTemperature());
+    addMeasurement(HDC1080_TEMPERSENSOR_ID, HDC.readTemperature());
     delay(200);
-    addMeasurement(RELLUFSENSOR_ID, HDC.readHumidity());
+    addMeasurement(HDC1080_RELLUFSENSOR_ID, HDC.readHumidity());
   #endif
 
   //-----Pressure-----//
   #ifdef BMP280_CONNECTED
     float pressure;
     pressure = BMP.readPressure()/100;
-    addMeasurement(LUFTDRSENSOR_ID, pressure);
+    addMeasurement(BMP280_LUFTDRSENSOR_ID, pressure);
   #endif
 
   //-----Lux-----//
   #ifdef TSL45315_CONNECTED
-    addMeasurement(BELEUCSENSOR_ID, Lightsensor_getIlluminance());
+    addMeasurement(TSL45315_BELEUCSENSOR_ID, Lightsensor_getIlluminance());
   #endif
 
   //-----UV intensity-----//
   #ifdef VEML6070_CONNECTED
-    addMeasurement(UVINTESENSOR_ID, VEML.getUV());
+    addMeasurement(VEML6070_UVINTESENSOR_ID, VEML.getUV());
   #endif
 
   //-----PM-----//
@@ -489,8 +489,8 @@ void loop() {
     while (attempt < 5) {
       bool error = SDS.read(&pm25, &pm10);
       if (!error) {
-        addMeasurement(PM10SENSOR_ID, pm10);
-        addMeasurement(PM25SENSOR_ID, pm25);
+        addMeasurement(SDS011_PM10SENSOR_ID, pm10);
+        addMeasurement(SDS011_PM25SENSOR_ID, pm25);
         break;
       }
       attempt++;
@@ -501,17 +501,17 @@ void loop() {
   #ifdef SMT50_CONNECTED
     float voltage = analogRead(SOILTEMPPIN) * (3.3 / 1024.0);
     float soilTemperature = (voltage - 0.5) * 100;
-    addMeasurement(BODENTSENSOR_ID, soilTemperature);
+    addMeasurement(SMT50_BODENTSENSOR_ID, soilTemperature);
     voltage = analogRead(SOILMOISPIN) * (3.3 / 1024.0);
     float soilMoisture = (voltage * 50) / 3;
-    addMeasurement(BODENFSENSOR_ID, soilMoisture);
+    addMeasurement(SMT50_BODENFSENSOR_ID, soilMoisture);
   #endif
 
   //-----dB(A) Sound Level-----//
   #ifdef SOUNDLEVELMETER_CONNECTED
     float v = analogRead(SOUNDMETERPIN) * (3.3 / 1024.0);
     float decibel = v * 50;
-    addMeasurement(LAUTSTSENSOR_ID, decibel);
+    addMeasurement(SOUNDLEVELMETER_LAUTSTSENSOR_ID, decibel);
   #endif
 
   //-----BME680-----//
@@ -519,14 +519,14 @@ void loop() {
     float gasResistance;
     BME.setGasHeater(0, 0);
     if( BME.performReading()) {
-       addMeasurement(LUFTTESENSOR_ID, BME.temperature-1);
-       addMeasurement(LUFTFESENSOR_ID, BME.humidity);
-       addMeasurement(ATMLUFSENSOR_ID, BME.pressure/100);
+       addMeasurement(BME680_LUFTTESENSOR_ID, BME.temperature-1);
+       addMeasurement(BME680_LUFTFESENSOR_ID, BME.humidity);
+       addMeasurement(BME680_ATMLUFSENSOR_ID, BME.pressure/100);
     }
     BME.setGasHeater(320, 150); // 320*C for 150 ms
     if( BME.performReading()) {
        gasResistance = BME.gas_resistance / 1000.0;
-       addMeasurement(VOCSENSOR_ID, gasResistance);
+       addMeasurement(BME680_VOCSENSOR_ID, gasResistance);
     }
   #endif
 
@@ -544,19 +544,19 @@ void loop() {
       windspeed = poly1 - poly2 + poly3 - poly4;
       windspeed = windspeed * 0.2777777777777778; //conversion in m/s
     }
-    addMeasurement(WINDGESENSOR_ID, windspeed);
+    addMeasurement(WINDSPEED_WINDGESENSOR_ID, windspeed);
   #endif
 
   //-----CO2-----//
   #ifdef SCD30_CONNECTED
-    addMeasurement(CO2SENSOR_ID, SCD.getCO2());
+    addMeasurement(SCD30_CO2SENSOR_ID, SCD.getCO2());
   #endif
 
   //-----DPS310 Pressure-----//
   #ifdef DPS310_CONNECTED
     sensors_event_t temp_event, pressure_event;
     dps.getEvents(&temp_event, &pressure_event);
-    addMeasurement(DPS310SENSOR_ID, pressure_event.pressure);
+    addMeasurement(DPS310_LUFTDRSENSOR_ID, pressure_event.pressure);
   #endif
 
   DEBUG(F("Submit values"));

--- a/test/0-included-templates.js
+++ b/test/0-included-templates.js
@@ -11,32 +11,32 @@ const testDomain = 'test.domain.com';
 
 const templateLocation = './templates';
 
-describe('Included templates', function() {
+describe('Included templates', function () {
   let globalconsolewarn, mySketchTemplater;
-  before(function() {
+  before(function () {
     globalconsolewarn = global.console.warn;
-    global.console.warn = function(err) {
+    global.console.warn = function (err) {
       throw new Error(err);
     };
 
     mySketchTemplater = new SketchTemplater(testDomain);
   });
 
-  after(function() {
+  after(function () {
     global.console.warn = globalconsolewarn;
   });
 
-  it('should not show any warnings', function() {
+  it('should not show any warnings', function () {
     expect(() => helpers.readTemplates(templateLocation)).to.not.throw();
   });
 
-  it('should load without warnings', function() {
+  it('should load without warnings', function () {
     const templates = helpers.readTemplates(templateLocation);
     expect(templates).to.be.a('object');
     expect(templates).to.not.be.empty;
   });
 
-  it('should execute custom model and make all substitutions', function() {
+  it('should execute custom model and make all substitutions', function () {
     const box = Object.assign({ model: 'custom' }, testBox());
     const sketch = mySketchTemplater.generateSketch(box);
 
@@ -49,7 +49,7 @@ describe('Included templates', function() {
     }
   });
 
-  it('should execute lora model and make all substitutions', function() {
+  it('should execute lora model and make all substitutions', function () {
     const box = Object.assign({ model: 'homeV2Lora' }, testBoxNewSensors());
 
     const sketch = mySketchTemplater.generateSketch(box);
@@ -63,7 +63,7 @@ describe('Included templates', function() {
     }
   });
 
-  it('should execute all other templates to execute and make all substitutions', function() {
+  it('should execute all other templates to execute and make all substitutions', function () {
     for (const model of Object.keys(mySketchTemplater._templates)) {
       if (model !== 'custom' && model !== 'homeV2Lora') {
         const box = Object.assign({ model: model }, testBox());
@@ -88,13 +88,13 @@ describe('Included templates', function() {
     }
   });
 
-  it('should return error string for unknown model', function() {
+  it('should return error string for unknown model', function () {
     expect(mySketchTemplater.generateSketch({ model: 'nosketch' })).to.include(
       'Error: No sketch template availiable for model'
     );
   });
 
-  it('should return a sketch in base64 encoding when requested', function() {
+  it('should return a sketch in base64 encoding when requested', function () {
     const box = Object.assign({ model: 'custom' }, testBox());
     // baseline sketch in text format
     const sketch = mySketchTemplater.generateSketch(box);
@@ -106,7 +106,7 @@ describe('Included templates', function() {
     ).to.equal(b64Sketch);
   });
 
-  it('should return a sketch with correct digital ports for soil moisture sensor, sound meter and wind sensor', function() {
+  it('should return a sketch with correct digital ports for soil moisture sensor, sound meter and wind sensor', function () {
     const box = Object.assign({ model: 'homeV2Wifi' }, testBoxNewSensors());
     // baseline sketch in text format
     const sketch = mySketchTemplater.generateSketch(box);
@@ -117,7 +117,7 @@ describe('Included templates', function() {
     expect(sketch).to.include(`WINDSPEEDPIN 1`);
   });
 
-  it('should return a sketch with correct authorization header', function() {
+  it('should return a sketch with correct authorization header', function () {
     const box = Object.assign({ model: 'homeV2Wifi' }, testBoxNewSensors());
     // baseline sketch in text format
     const sketch = mySketchTemplater.generateSketch(box);
@@ -127,20 +127,20 @@ describe('Included templates', function() {
     );
   });
 
-  it('should return a sketch with CO2 sensor', function() {
+  it('should return a sketch with CO2 sensor', function () {
     const box = Object.assign({ model: 'homeV2Wifi' }, testBoxNewSensors());
     // baseline sketch in text format
     const sketch = mySketchTemplater.generateSketch(box);
 
     expect(sketch).to.include(`#define SCD30_CONNECTED`);
-    expect(sketch).to.include(`const char CO2SENSOR_ID[] PROGMEM`);
+    expect(sketch).to.include(`const char SCD30_CO2SENSOR_ID[] PROGMEM`);
   });
 
-  it('should return a sketch with DPS310 sensor', function() {
+  it('should return a sketch with DPS310 sensor', function () {
     const box = Object.assign({ model: 'homeV2Wifi' }, testBox());
     // baseline sketch in text format
     const sketch = mySketchTemplater.generateSketch(box);
 
-    expect(sketch).to.include(`const char DPS310SENSOR_ID[] PROGMEM =`);
+    expect(sketch).to.include(`const char DPS310_LUFTDRSENSOR_ID[] PROGMEM =`);
   });
 });

--- a/test/1-template-config-parsing.js
+++ b/test/1-template-config-parsing.js
@@ -6,38 +6,38 @@ const expect = require('chai').expect,
 
 const templateLocation = './test/test-templates';
 
-describe('Template config parsing', function() {
+describe('Template config parsing', function () {
   let globalconsolewarn;
-  before(function() {
+  before(function () {
     globalconsolewarn = global.console.warn;
-    global.console.warn = function(err) {
+    global.console.warn = function (err) {
       throw new Error(err);
     };
   });
 
-  after(function() {
+  after(function () {
     global.console.warn = globalconsolewarn;
   });
 
-  it('should show a warning when the syntax is wrong', function() {
+  it('should show a warning when the syntax is wrong', function () {
     expect(() =>
       helpers.readTemplates(`${templateLocation}/wrong-syntax`)
     ).to.throw(/Missing or invalid/);
   });
 
-  it('should show a warning when there is no model declaration', function() {
+  it('should show a warning when there is no model declaration', function () {
     expect(() =>
       helpers.readTemplates(`${templateLocation}/missing-model-models-key`)
     ).to.throw(/Key "model" or "models" not found/);
   });
 
-  it('should show a warning for duplicate model declaration', function() {
+  it('should show a warning for duplicate model declaration', function () {
     expect(() =>
       helpers.readTemplates(`${templateLocation}/duplicate-model`)
     ).to.throw(/Duplicate declaration of model/);
   });
 
-  it('should show a warning when keys "model" and "models" defined at the same time', function() {
+  it('should show a warning when keys "model" and "models" defined at the same time', function () {
     expect(() =>
       helpers.readTemplates(`${templateLocation}/model-models-same-time`)
     ).to.throw(
@@ -45,7 +45,7 @@ describe('Template config parsing', function() {
     );
   });
 
-  it('should show a warning for invalid model definition', function() {
+  it('should show a warning for invalid model definition', function () {
     expect(() =>
       helpers.readTemplates(`${templateLocation}/model-invalid`)
     ).to.throw(/is invalid/);

--- a/test/2-transformers.js
+++ b/test/2-transformers.js
@@ -5,13 +5,13 @@ const expect = require('chai').expect,
   testBox = require('./test-data/testBox_newSensors'),
   transformers = require('../src/transformers');
 
-describe('Transformers', function() {
-  it('as-is should just return whats given', function() {
+describe('Transformers', function () {
+  it('as-is should just return whats given', function () {
     const teststring = 'I am a teststring';
     expect(transformers['as-is'](teststring)).to.equal(teststring);
   });
 
-  it('toDefine should transform a sensor array to multiple lines with #defines', function() {
+  it('toDefine should transform a sensor array to multiple lines with #defines', function () {
     const { sensors } = testBox();
 
     const result = transformers.toDefine(sensors);
@@ -25,7 +25,7 @@ describe('Transformers', function() {
     }
   });
 
-  it('toDefineWithPrefixAndSuffix should transform a sensor array to multiple lines with #defines', function() {
+  it('toDefineWithPrefixAndSuffix should transform a sensor array to multiple lines with #defines', function () {
     const { sensors } = testBox();
     const prefix = '';
     const suffix = '_CONNECTED';
@@ -48,7 +48,7 @@ describe('Transformers', function() {
     }
   });
 
-  it('toProgmem should transform a sensor array to multiple lines with PROGMEM chars', function() {
+  it('toProgmem should transform a sensor array to multiple lines with PROGMEM chars', function () {
     const { sensors } = testBox();
 
     const result = transformers.toProgmem(sensors);
@@ -62,7 +62,7 @@ describe('Transformers', function() {
     }
   });
 
-  it('transformTTNID should transform a strign to a C compatible hex array', function() {
+  it('transformTTNID should transform a strign to a C compatible hex array', function () {
     const { devEUI, appEUI, appKey } = testBox();
 
     const devEUITransformed = transformers.transformTTNID(devEUI, true);

--- a/test/test-data/testBox.js
+++ b/test/test-data/testBox.js
@@ -24,7 +24,11 @@ module.exports = function testBox() {
         _id: randomHex(),
         sensorType: 'HDC1080'
       },
-      { title: 'DPS310 Luftdruck', _id: randomHex(), sensorType: 'DPS310' }
+      {
+        title: 'Luftdruck',
+        _id: randomHex(),
+        sensorType: 'DPS310'
+      }
     ],
     serialPort: 'Serial1',
     ssid: 'MY-HOME-NETWORK',


### PR DESCRIPTION
- Variable names for sensor ids are now: `SENSORTYPE_TITLESESNOR_ID` (first 6 characters are taken)
- Some `eslint` rules
- Update test cases

## Why?
We have different sensors that are measuring the same phenomenon. The sensor ids would always have the same variable names. With this change they become unique.