### PR TITLE
export arduino builds in action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,11 +52,11 @@ jobs:
       - name: Archive build artifact
         uses: actions/upload-artifact@master
         with:
-          name: build-artifact
+          name: node-sketch-templater-build-artifact
           path: ${{ github.workspace }}/arduino-test/build
 
       - name: Download build artifact
         uses: actions/download-artifact@master
         with:
-          name: build-artifact
+          name: node-sketch-templater-build-artifact
           path: ./

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build docker image
         run: docker build -t arduino-test .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,20 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      - name: Build docker image
+        run: docker build -t arduino-test .
+
       - name: Execute arduino-test
-        run: |
-          npm run arduino-test
+        run:  docker run -v ${{ github.workspace }}/arduino-test/build:/app/arduino-test/sketches arduino-test
+
+      - name: Archive build artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: build-artifact
+          path: ${{ github.workspace }}/arduino-test/build
+
+      - name: Download build artifact
+        uses: actions/download-artifact@master
+        with:
+          name: build-artifact
+          path: ./

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .vscode
 arduino-test/sketches
+arduino-test/build

--- a/arduino-test/build-sketches.js
+++ b/arduino-test/build-sketches.js
@@ -114,7 +114,7 @@ const build = function build(board, model) {
     `Building model ${model} with "arduino-cli compile --fqbn ${board} ${sketchesPath}/${model}/${model}.ino"`
   );
   child_process.execSync(
-    `arduino-cli compile --fqbn ${board} ${sketchesPath}/${model}/${model}.ino`,
+    `arduino-cli compile --fqbn ${board} -e ${sketchesPath}/${model}/${model}.ino`,
     // `arduino --verbose-build --verify --board ${board} ${sketchesPath}/${model}/${model}.ino`,
     { stdio: [0, 1, 2] }
   );


### PR DESCRIPTION
This PR exports the `arduino-test` builds automatically as artifacts from the GH Action. The `.bin` files can directly be transferred to a senseBox in order to test the latest changes